### PR TITLE
ADD: Add setup.cfg to define line length

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 90


### PR DESCRIPTION
Adding a `setup.cfg` to the repository to set line length to 90 instead of 79, which is in accordance with PEP8.